### PR TITLE
6-GET /api/articles/:article_id/comments (UPDATED)

### DIFF
--- a/__tests__/seed.test.js
+++ b/__tests__/seed.test.js
@@ -36,12 +36,13 @@ describe("GET /api/topics", () => {
     return request(app)
       .get("/api/topics")
       .expect(200)
-      .then(({ body }) => {
-        const topics = body;
+      .then(({ body:{topics} }) => {
         expect(topics.length).toBe(3);
         topics.forEach((topic) => {
-          expect(typeof topic.slug).toBe("string");
-          expect(typeof topic.description).toBe("string");
+          expect(topic).toMatchObject({
+            slug: expect.any(String),
+            description: expect.any(String),
+          });
         });
       });
   });
@@ -53,23 +54,25 @@ describe("GET /api/articles/:article_id", () => {
       .get("/api/articles/1")
       .expect(200)
       .then(({ body: { article } }) => {
-        expect(typeof article.author).toBe("string");
-        expect(typeof article.title).toBe("string");
-        expect(typeof article.article_id).toBe("number");
-        expect(typeof article.body).toBe("string");
-        expect(typeof article.topic).toBe("string");
-        expect(typeof article.created_at).toBe("string");
-        expect(typeof article.votes).toBe("number");
-        expect(typeof article.article_img_url).toBe("string");
+        expect(article).toMatchObject({
+          author: expect.any(String),
+          title: expect.any(String),
+          article_id: expect.any(Number),
+          body: expect.any(String),
+          topic: expect.any(String),
+          created_at: expect.any(String),
+          votes: expect.any(Number),
+          article_img_url: expect.any(String),
+        });
       });
   });
-  test("GET400: Invalid ID Input", () => {
+  test("GET404: Non-existent ID", () => {
     return request(app)
       .get("/api/articles/99")
-      .expect(400)
+      .expect(404)
       .then(({ body }) => {
         const { msg } = body;
-        expect(msg).toBe("Invalid ID Input");
+        expect(msg).toBe("Non-existent ID");
       });
   });
   test("GET400: Invalid Input Type", () => {
@@ -92,14 +95,16 @@ describe("GET /api/articles", () => {
         expect(allArticles.length).toBe(13);
         expect(allArticles).toBeSortedBy("created_at", { descending: true });
         allArticles.forEach((article) => {
-          expect(typeof article.author).toBe("string");
-          expect(typeof article.title).toBe("string");
-          expect(typeof article.article_id).toBe("number");
-          expect(typeof article.topic).toBe("string");
-          expect(typeof article.created_at).toBe("string");
-          expect(typeof article.votes).toBe("number");
-          expect(typeof article.article_img_url).toBe("string");
-          expect(typeof article.comment_count).toBe("number");
+          expect(article).toMatchObject({
+            author: expect.any(String),
+            title: expect.any(String),
+            article_id: expect.any(Number),
+            topic: expect.any(String),
+            created_at: expect.any(String),
+            votes: expect.any(Number),
+            article_img_url: expect.any(String),
+            comment_count: expect.any(Number),
+          });
         });
       });
   });
@@ -114,31 +119,33 @@ describe("GET /api/articles/:article_id/comments", () => {
         expect(allComments.length).toBe(11);
         expect(allComments).toBeSortedBy("created_at", { descending: true });
         allComments.forEach((comment) => {
-          expect(typeof comment.comment_id).toBe("number");
-          expect(typeof comment.votes).toBe("number");
-          expect(typeof comment.created_at).toBe("string");
-          expect(typeof comment.author).toBe("string");
-          expect(typeof comment.body).toBe("string");
-          expect(comment.article_id).toBe(1);
+          expect(comment).toMatchObject({
+            comment_id: expect.any(Number),
+            votes: expect.any(Number),
+            created_at: expect.any(String),
+            author: expect.any(String),
+            body: expect.any(String),
+            article_id: 1,
+          });
         });
       });
-  }) ;
-  test("GET400: Invalid ID Input", () => {
-    return request(app)
-      .get("/api/articles/99/comments")
-      .expect(400)
-      .then(({ body }) => {
-        const { msg } = body;
-        expect(msg).toBe("Invalid ID Input");
-      });
   });
-  test("GET400: Invalid Input Type", () => {
-    return request(app)
-      .get("/api/articles/not-a-number/comments")
-      .expect(400)
-      .then(({ body }) => {
-        const { msg } = body;
-        expect(msg).toBe("Invalid ID Type");
-      });
-  });
+});
+test("GET404: Invalid ID Input", () => {
+  return request(app)
+    .get("/api/articles/99/comments")
+    .expect(404)
+    .then(({ body }) => {
+      const { msg } = body;
+      expect(msg).toBe("Non-existent ID");
+    });
+});
+test("GET400: Invalid Input Type", () => {
+  return request(app)
+    .get("/api/articles/not-a-number/comments")
+    .expect(400)
+    .then(({ body }) => {
+      const { msg } = body;
+      expect(msg).toBe("Invalid ID Type");
+    });
 });

--- a/app.js
+++ b/app.js
@@ -3,7 +3,6 @@ const app = express();
 const endpoints = require("./endpoints.json");
 
 app.use(express.json());
-app.get;
 
 const { getTopics, getArticleById , getArticles, getCommentsByArticleID} = require("./controllers");
 

--- a/controllers.js
+++ b/controllers.js
@@ -2,7 +2,7 @@ const { fetchTopics, fetchArticleById, fetchArticles, fetchCommentsByArticleID }
 
 exports.getTopics = (req, res, next) => {
   fetchTopics().then((topics) => {
-    res.status(200).send(topics);
+    res.status(200).send({topics});
   });
 };
 

--- a/model.js
+++ b/model.js
@@ -11,7 +11,7 @@ exports.fetchArticleById = (article_id) => {
     .query(`SELECT * FROM articles WHERE article_id = $1`, [article_id])
     .then(({ rows }) => {
       if (rows.length === 0) {
-        return Promise.reject({ status: 400, msg: "Invalid ID Input" });
+        return Promise.reject({ status: 404, msg: "Non-existent ID" });
       }
       return rows[0];
     });
@@ -43,7 +43,7 @@ exports.fetchCommentsByArticleID = (article_id,sort_by = "created_at", order = "
     return db.query(sqlQueryString,[article_id])
     .then(({rows})=>{
         if (rows.length === 0) {
-            return Promise.reject({ status: 400, msg: "Invalid ID Input" });
+            return Promise.reject({ status: 404, msg: "Non-existent ID" });
           }
         return rows
     })


### PR DESCRIPTION
created new endpoint of: /api/articles/:article_id/comments

Happy Path:
GET200 : responds with an array of comments objects from selected article by article ID. Comments served with the most recent comments first.

Sad Path:
GET404: Non-existent ID
GET400: Invalid Input Type


*Refactored after reading feedback from mentors:
1. changed typeof to .toMatchObject in test suites
2. changed "400 Invalid Input ID" to "404 Non-existent ID"