### PR TITLE
7-post /api/articles/:article_id/comments

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -149,3 +149,68 @@ describe("GET /api/articles/:article_id/comments", () => {
       });
   });
 });
+
+describe("POST /api/articles/:article_id/comments", () => {
+  test("POST201: post a comment for an article(seleted by article ID), accept VARCHAR properties: username and body. Will responds with the newly posted comment", () => {
+    const newComment = {
+      username: "rogersop",
+      body: "Isn't that sweet, i guess so",
+    };
+    return request(app)
+      .post("/api/articles/2/comments")
+      .send(newComment)
+      .expect(201)
+      .then(({ body: { postedComment } }) => {
+        expect(postedComment).toMatchObject({
+          comment_id: 19,
+          votes: expect.any(Number),
+          created_at: expect.any(String),
+          author: newComment.username,
+          body: newComment.body,
+          article_id : 2
+        });
+      });
+  });
+  test("POST404: Respond with an error when passed ID is valid but non-existent", () => {
+    const newComment = {
+      username: "rogersop",
+      body: "Isn't that sweet, i guess so",
+    };
+    return request(app)
+      .post("/api/articles/99/comments")
+      .send(newComment)
+      .expect(404)
+      .then(({ body }) => {
+        const { msg } = body;
+        expect(msg).toBe("Non-existent Article ID / Username");
+      });
+  });
+  test("POST400: Respond with an error when an input article ID is the incorrect type", () => {
+    const newComment = {
+      username: "rogersop",
+      body: "Isn't that sweet, i guess so",
+    };
+    return request(app)
+      .post("/api/articles/not-a-number/comments")
+      .send(newComment)
+      .expect(400)
+      .then(({ body }) => {
+        const { msg } = body;
+        expect(msg).toBe("Invalid ID Type");
+      });
+  });
+  test("POST404: Respond with an error when new input comments type is incorrect", () => {
+    const newComment = {
+      username: 123,
+      body: "Isn't that sweet, i guess so",
+    };
+    return request(app)
+      .post("/api/articles/2/comments")
+      .send(newComment)
+      .expect(404)
+      .then(({ body }) => {
+        const { msg } = body;
+        expect(msg).toBe("Non-existent Article ID / Username");
+      });
+  });
+});

--- a/app.js
+++ b/app.js
@@ -4,7 +4,7 @@ const endpoints = require("./endpoints.json");
 
 app.use(express.json());
 
-const { getTopics, getArticleById , getArticles, getCommentsByArticleID} = require("./controllers");
+const { getTopics, getArticleById , getArticles, getCommentsByArticleID, postComment} = require("./controllers");
 
 //Respond a list of all available endpoints from endpoint.json
 app.get("/api", (req, res, next) => {
@@ -17,11 +17,12 @@ app.get("/api/articles/:article_id", getArticleById);
 app.get("/api/articles", getArticles)
 app.get("/api/articles/:article_id/comments", getCommentsByArticleID)
 
+app.post("/api/articles/:article_id/comments", postComment);
+
 //Error Handling Middleware
 app.all("*", (req, res) => {
   res.status(404).send("Invalid Endpoint");
 });
-
 
 app.use((err, req, res, next) => {
     //Non-existent ID
@@ -34,6 +35,10 @@ app.use((err, req, res, next) => {
 app.use((err, req, res, next) => {
   if (err.code === "22P02") {
     res.status(400).send({ msg: "Invalid ID Type" });
+  }
+
+  if(err.code === "23503"){
+    res.status(404).send({msg:"Non-existent Article ID / Username"})
   }
   next(err);
 });

--- a/controllers.js
+++ b/controllers.js
@@ -1,8 +1,15 @@
-const { fetchTopics, fetchArticleById, fetchArticles, fetchCommentsByArticleID } = require("./model");
+const comments = require("./db/data/test-data/comments");
+const {
+  fetchTopics,
+  fetchArticleById,
+  fetchArticles,
+  fetchCommentsByArticleID,
+  createComment,
+} = require("./model");
 
 exports.getTopics = (req, res, next) => {
   fetchTopics().then((topics) => {
-    res.status(200).send({topics});
+    res.status(200).send({ topics });
   });
 };
 
@@ -27,9 +34,21 @@ exports.getArticles = (req, res, next) => {
 exports.getCommentsByArticleID = (req, res, next) => {
   const { article_id } = req.params;
   const { sort_by, order } = req.query;
-  fetchCommentsByArticleID(article_id, sort_by, order).then((comments) => {
-    res.status(200).send({ allComments: comments });
+  fetchCommentsByArticleID(article_id, sort_by, order)
+    .then((comments) => {
+      res.status(200).send({ allComments: comments });
+    })
+    .catch((err) => {
+      next(err);
+    });
+};
+
+exports.postComment = (req, res, next) => {
+  const { article_id } = req.params;
+  const newComment = req.body;
+  createComment(article_id, newComment).then((comments) => {
+    res.status(201).send({ postedComment: comments });
   }).catch((err) => {
     next(err);
-  });
+  });;
 };

--- a/endpoints.json
+++ b/endpoints.json
@@ -60,5 +60,24 @@
         }
       ]
     }
+  },
+  "POST /api/articles/:article_id/comments":{
+    "description":"add a comment for an article (seleted by article ID), accept properties: username and body. Will responds with the posted comment.",
+    "queries": [],
+    "acceptProperties":{
+      "username" : "rogersop",
+      "body":"Isn't that sweet, i guess so"
+    },
+    "exampleResponse":{
+      "postedComment":[
+        {"comment_id":19,
+        "votes":22,
+        "created_at":"2020-07-09T20:11:00.000Z",
+        "author":"rogersop",
+        "body":"Isn't that sweet, i guess so",
+        "article_id":"2"
+      }
+      ]
+    }
   }
 }

--- a/model.js
+++ b/model.js
@@ -48,3 +48,11 @@ exports.fetchCommentsByArticleID = (article_id,sort_by = "created_at", order = "
         return rows
     })
 }
+
+exports.createComment = (article_id,newComment)=>{
+    return db
+    .query(`INSERT INTO comments(author,body,article_id) VALUES ($1,$2,$3) RETURNING *;`,[newComment.username,newComment.body,article_id])
+    .then(({rows})=>{
+        return rows[0]
+    })
+}


### PR DESCRIPTION
add new endpoint for: POST /api/articles/:article_id/comments

this POST endpoint accepts two properties (username and body) and post new comment, and will respond with the new created comment.

Happy Path:
POST201: article_id valid and exist, input fits sql requirement and will respond with new created comment

Sad Path:
POST404: Respond with an error when passed ID is valid but non-existent
POST400: Respond with an error when an input article ID is the incorrect type
POST404: Respond with an error when new input comments type is incorrect