### PR TITLE
8-patch articles/article

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -81,7 +81,7 @@ describe("GET /api/articles/:article_id", () => {
       .expect(400)
       .then(({ body }) => {
         const { msg } = body;
-        expect(msg).toBe("Invalid ID Type");
+        expect(msg).toBe("Bad Request");
       });
   });
 });
@@ -137,16 +137,16 @@ describe("GET /api/articles/:article_id/comments", () => {
       .then(({ body: { allComments } }) => {
         allComments.forEach((comment) => {
           expect(comment).toEqual([]);
-          });
         });
       });
+  });
   test("GET404: Respond with an error when passed ID is valid but non-existent", () => {
     return request(app)
       .get("/api/articles/99/comments")
       .expect(404)
       .then(({ body }) => {
         const { msg } = body;
-        expect(msg).toBe("Non-existent ID");
+        expect(msg).toBe("Non-existent Article ID");
       });
   });
   test("GET400: Respond with an error when passed an ID that is of the incorrect type", () => {
@@ -155,7 +155,7 @@ describe("GET /api/articles/:article_id/comments", () => {
       .expect(400)
       .then(({ body }) => {
         const { msg } = body;
-        expect(msg).toBe("Invalid ID Type");
+        expect(msg).toBe("Bad Request");
       });
   });
 });
@@ -177,11 +177,11 @@ describe("POST /api/articles/:article_id/comments", () => {
           created_at: expect.toBeDateString(),
           author: newComment.username,
           body: newComment.body,
-          article_id : 2
+          article_id: 2,
         });
       });
   });
-  test("POST404: Respond with an error when passed ID is valid but non-existent", () => {
+  test("POST404: Respond with an error when passed ID is valid but non-existent. ", () => {
     const newComment = {
       username: "rogersop",
       body: "Isn't that sweet, i guess so",
@@ -206,7 +206,7 @@ describe("POST /api/articles/:article_id/comments", () => {
       .expect(400)
       .then(({ body }) => {
         const { msg } = body;
-        expect(msg).toBe("Invalid ID Type");
+        expect(msg).toBe("Bad Request");
       });
   });
   test("POST404: Respond with an error when new input comments type is incorrect", () => {
@@ -225,7 +225,7 @@ describe("POST /api/articles/:article_id/comments", () => {
   });
   test("POST400: Respond with an error when incomplete/missing body", () => {
     const newComment = {
-      username: 123
+      username: "rogersop"
     };
     return request(app)
       .post("/api/articles/2/comments")
@@ -234,6 +234,79 @@ describe("POST /api/articles/:article_id/comments", () => {
       .then(({ body }) => {
         const { msg } = body;
         expect(msg).toBe("Incomplete/Missing Body");
+      });
+  });
+});
+
+describe("PATCH /api/articles/:article_id", () => {
+  test("PATCH200: update an article by article_id, ", () => {
+    const newVote = {
+      inc_votes: 1,
+    };
+    return request(app)
+      .patch("/api/articles/1")
+      .send(newVote)
+      .expect(200)
+      .then(({ body: { updatedArticle } }) => {
+        expect(updatedArticle).toMatchObject({
+          author: expect.any(String),
+          title: expect.any(String),
+          article_id: expect.any(Number),
+          topic: expect.any(String),
+          created_at: expect.toBeDateString(),
+          votes: 101,
+          article_img_url: expect.any(String)
+        });
+      });
+  });
+  test("PATCH400: Respond with an error when newVote is not in the required obj key pair value form", () => {
+    const newVote = "1";
+    return request(app)
+      .patch("/api/articles/1")
+      .send(newVote)
+      .expect(400)
+      .then(({body}) => {
+        const { msg } = body;
+        expect(msg).toBe("Invalid Form Body");
+      });
+  });
+  test("PATCH404: Respond with an error when passed ID is valid but non-existent.", () => {
+    const newVote = {
+      inc_votes: 1,
+    };
+    return request(app)
+      .patch("/api/articles/99")
+      .send(newVote)
+      .expect(404)
+      .then(({ body }) => {
+        const { msg } = body;
+        expect(msg).toBe("Non-existent Article ID");
+      });
+  });
+  test("PATCH400: Respond with an error when an input article ID is the incorrect type", () => {
+    const newVote = {
+      inc_votes: 1,
+    };
+    return request(app)
+      .patch("/api/articles/not-a-number")
+      .send(newVote)
+      .expect(400)
+      .then(({ body }) => {
+        const { msg } = body;
+        expect(msg).toBe("Bad Request");
+      });
+  });
+  test("PATCH400: Respond with an error when invalid body", () => {
+    const newVote = {
+      inc_votes: "abc",
+    };
+    return request(app)
+      .patch("/api/articles/1")
+      .send(newVote)
+      .expect(400)
+      .then(({ body }) => {
+        const { msg } = body;
+        expect(msg).toBe("Bad Request");
       });
   });
 });

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -239,7 +239,7 @@ describe("POST /api/articles/:article_id/comments", () => {
 });
 
 describe("PATCH /api/articles/:article_id", () => {
-  test("PATCH200: update an article by article_id, ", () => {
+  test("PATCH200: update an article by article_id, and respond with new updated article ", () => {
     const newVote = {
       inc_votes: 1,
     };

--- a/app.js
+++ b/app.js
@@ -4,7 +4,14 @@ const endpoints = require("./endpoints.json");
 
 app.use(express.json());
 
-const { getTopics, getArticleById , getArticles, getCommentsByArticleID, postComment} = require("./controllers");
+const {
+  getTopics,
+  getArticleById,
+  getArticles,
+  getCommentsByArticleID,
+  postComment,
+  patchArticle,
+} = require("./controllers");
 
 //Respond a list of all available endpoints from endpoint.json
 app.get("/api", (req, res, next) => {
@@ -14,10 +21,11 @@ app.get("/api", (req, res, next) => {
 app.get("/api/topics", getTopics);
 
 app.get("/api/articles/:article_id", getArticleById);
-app.get("/api/articles", getArticles)
-app.get("/api/articles/:article_id/comments", getCommentsByArticleID)
+app.get("/api/articles", getArticles);
+app.get("/api/articles/:article_id/comments", getCommentsByArticleID);
 
 app.post("/api/articles/:article_id/comments", postComment);
+app.patch("/api/articles/:article_id", patchArticle);
 
 //Error Handling Middleware
 app.all("*", (req, res) => {
@@ -25,7 +33,7 @@ app.all("*", (req, res) => {
 });
 
 app.use((err, req, res, next) => {
-    //Non-existent ID
+  //Non-existent ID
   if (err.status && err.msg) {
     res.status(err.status).send({ msg: err.msg });
   }
@@ -34,15 +42,15 @@ app.use((err, req, res, next) => {
 
 app.use((err, req, res, next) => {
   if (err.code === "22P02") {
-    res.status(400).send({ msg: "Invalid ID Type" });
+    res.status(400).send({ msg: "Bad Request" });
   }
 
-  if(err.code === "23503"){
-    res.status(404).send({msg:"Non-existent Article ID / Username"})
+  if (err.code === "23503") {
+    res.status(404).send({ msg: "Non-existent Article ID / Username" });
   }
 
-  if(err.code === "23502"){
-    res.status(400).send({msg: "Incomplete/Missing Body" })
+  if (err.code === "23502") {
+    res.status(400).send({ msg: "Incomplete/Missing Body" });
   }
   next(err);
 });

--- a/controllers.js
+++ b/controllers.js
@@ -6,6 +6,7 @@ const {
   fetchCommentsByArticleID,
   checkArticleExists,
   createComment,
+  updatedArticle,
 } = require("./model");
 
 exports.getTopics = (req, res, next) => {
@@ -36,7 +37,10 @@ exports.getCommentsByArticleID = (req, res, next) => {
   const { article_id } = req.params;
   const { sort_by, order } = req.query;
 
-  Promise.all([fetchCommentsByArticleID(article_id, sort_by, order),checkArticleExists(article_id)])
+  Promise.all([
+    fetchCommentsByArticleID(article_id, sort_by, order),
+    checkArticleExists(article_id),
+  ])
     .then(([comments]) => {
       res.status(200).send({ allComments: comments });
     })
@@ -48,8 +52,20 @@ exports.getCommentsByArticleID = (req, res, next) => {
 exports.postComment = (req, res, next) => {
   const { article_id } = req.params;
   const newComment = req.body;
-  createComment(article_id, newComment).then((comments) => {
-    res.status(201).send({ postedComment: comments });
+  createComment(article_id, newComment)
+    .then((comments) => {
+      res.status(201).send({ postedComment: comments });
+    })
+    .catch((err) => {
+      next(err);
+    });
+};
+
+exports.patchArticle = (req, res, next) => {
+  const { article_id } = req.params;
+  const { inc_votes } = req.body;
+  updatedArticle(article_id, inc_votes).then((article) => {
+    res.status(200).send({ updatedArticle: article });
   }).catch((err) => {
     next(err);
   });;

--- a/endpoints.json
+++ b/endpoints.json
@@ -64,11 +64,11 @@
   "POST /api/articles/:article_id/comments":{
     "description":"add a comment for an article (seleted by article ID), accept properties: username and body. Will responds with the posted comment.",
     "queries": [],
-    "acceptProperties":{
+    " exampleRequest":{
       "username" : "rogersop",
       "body":"Isn't that sweet, i guess so"
     },
-    "exampleRequest":{
+    "exampleResponse":{
       "postedComment":[
         {"comment_id":19,
         "votes":22,
@@ -78,6 +78,24 @@
         "article_id":"2"
       }
       ]
+    }
+  },
+  "PATCH /api/articles/:article_id":{
+    "description":"update an article by article_id, accept properties: newVotes (in the form of key pair values, ex: { inc_votes : 1 }, which increase the selected article's vote by 1), and responds with the updated article.",
+    "queries":[],
+    "exampleRequest":{
+      "inc_votes" : 1 
+    },
+    "exampleResponse":{
+      "updatedArticle":[{
+        "article_id":1,
+        "title": "Living in the shadow of a great man",
+        "topic": "mitch",
+        "author": "butter_bridge",
+        "created_at": "2020-07-09T20:11:00.000Z",
+        "votes": 101,
+        "article_img_url": "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700"
+      }]
     }
   }
 }

--- a/model.js
+++ b/model.js
@@ -50,7 +50,7 @@ exports.checkArticleExists = (article_id) => {
     return db.query(`SELECT * FROM articles WHERE article_id = $1`,[article_id])
     .then(({rows})=>{
         if (rows.length === 0) {
-            return Promise.reject({ status: 404, msg: "Non-existent ID" });
+            return Promise.reject({ status: 404, msg: "Non-existent Article ID" });
           }
         return rows
     })
@@ -60,6 +60,20 @@ exports.createComment = (article_id,newComment)=>{
     return db
     .query(`INSERT INTO comments(author,body,article_id) VALUES ($1,$2,$3) RETURNING *;`,[newComment.username,newComment.body,article_id])
     .then(({rows})=>{
+        return rows[0]
+    })
+}
+
+exports.updatedArticle = (article_id, inc_votes) =>{
+    if(!inc_votes){
+        return Promise.reject({status:400,msg:"Invalid Form Body"})
+    }
+    return db
+    .query(`UPDATE articles SET votes = votes + $1 WHERE article_id = $2 RETURNING *;`,[inc_votes,article_id])
+    .then(({rows})=>{
+        if (rows.length === 0) {
+            return Promise.reject({ status: 404, msg: "Non-existent Article ID" });
+          }
         return rows[0]
     })
 }


### PR DESCRIPTION
created new endpoint of: PATCH /api/articles/:article_id

This patch endpoint should update an article by article_id, accept properties: newVotes (in the form of key pair values, ex: { inc_votes : 1 }, which increase the selected article's vote by 1), and responds with the updated article.

Happy Path:
PATCH200: update an article by article_id, and respond with new updated article

Sad Path:
PATCH400: Respond with an error when newVote is not in the required obj key pair value form
PATCH404: Respond with an error when passed ID is valid but non-existent
PATCH400: Respond with an error when an input article ID is the incorrect type
PATCH400: Respond with an error when invalid body
