### PR TITLE
9-delete /api/comments/:comment_id

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -225,7 +225,7 @@ describe("POST /api/articles/:article_id/comments", () => {
   });
   test("POST400: Respond with an error when incomplete/missing body", () => {
     const newComment = {
-      username: "rogersop"
+      username: "rogersop",
     };
     return request(app)
       .post("/api/articles/2/comments")
@@ -255,7 +255,7 @@ describe("PATCH /api/articles/:article_id", () => {
           topic: expect.any(String),
           created_at: expect.toBeDateString(),
           votes: 101,
-          article_img_url: expect.any(String)
+          article_img_url: expect.any(String),
         });
       });
   });
@@ -265,7 +265,7 @@ describe("PATCH /api/articles/:article_id", () => {
       .patch("/api/articles/1")
       .send(newVote)
       .expect(400)
-      .then(({body}) => {
+      .then(({ body }) => {
         const { msg } = body;
         expect(msg).toBe("Invalid Form Body");
       });
@@ -303,6 +303,35 @@ describe("PATCH /api/articles/:article_id", () => {
     return request(app)
       .patch("/api/articles/1")
       .send(newVote)
+      .expect(400)
+      .then(({ body }) => {
+        const { msg } = body;
+        expect(msg).toBe("Bad Request");
+      });
+  });
+});
+
+describe("DELETE /api/comments/:comment_id", () => {
+  test("DELETE204: delete the given comment by comment_id", () => {
+    return request(app)
+      .delete("/api/comments/1")
+      .expect(204)
+      .then(({ body }) => {
+        expect(body).toEqual({});
+      });
+  });
+  test("DELETE404: Respond with an error when passed ID is valid but non-existent.", () => {
+    return request(app)
+      .delete("/api/comments/99")
+      .expect(404)
+      .then(({ body }) => {
+        const { msg } = body;
+        expect(msg).toBe("Non-existent Comment ID");
+      });
+  });
+  test.only("DELETE400: Respond with an error when an input comment ID is the incorrect type", () => {
+    return request(app)
+      .delete("/api/comments/not-a-number")
       .expect(400)
       .then(({ body }) => {
         const { msg } = body;

--- a/app.js
+++ b/app.js
@@ -11,6 +11,7 @@ const {
   getCommentsByArticleID,
   postComment,
   patchArticle,
+  deleteComment
 } = require("./controllers");
 
 //Respond a list of all available endpoints from endpoint.json
@@ -26,6 +27,8 @@ app.get("/api/articles/:article_id/comments", getCommentsByArticleID);
 
 app.post("/api/articles/:article_id/comments", postComment);
 app.patch("/api/articles/:article_id", patchArticle);
+
+app.delete("/api/comments/:comment_id",deleteComment)
 
 //Error Handling Middleware
 app.all("*", (req, res) => {

--- a/controllers.js
+++ b/controllers.js
@@ -7,6 +7,7 @@ const {
   checkArticleExists,
   createComment,
   updatedArticle,
+  removeComment,
 } = require("./model");
 
 exports.getTopics = (req, res, next) => {
@@ -64,9 +65,22 @@ exports.postComment = (req, res, next) => {
 exports.patchArticle = (req, res, next) => {
   const { article_id } = req.params;
   const { inc_votes } = req.body;
-  updatedArticle(article_id, inc_votes).then((article) => {
-    res.status(200).send({ updatedArticle: article });
-  }).catch((err) => {
-    next(err);
-  });;
+  updatedArticle(article_id, inc_votes)
+    .then((article) => {
+      res.status(200).send({ updatedArticle: article });
+    })
+    .catch((err) => {
+      next(err);
+    });
+};
+
+exports.deleteComment = (req, res, next) => {
+  const { comment_id } = req.params;
+  removeComment(comment_id)
+    .then((result) => {
+      res.status(204).send(result);
+    })
+    .catch((err) => {
+      next(err);
+    });
 };

--- a/endpoints.json
+++ b/endpoints.json
@@ -97,5 +97,10 @@
         "article_img_url": "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700"
       }]
     }
+  },
+  "DELETE /api/comments/:comment_id":{
+    "description":"delete the given comment by comment_id",
+    "queries":[],
+    "exampleResponse":"status 204 and no content"
   }
 }

--- a/model.js
+++ b/model.js
@@ -77,3 +77,14 @@ exports.updatedArticle = (article_id, inc_votes) =>{
         return rows[0]
     })
 }
+
+exports.removeComment = (comment_id) =>{
+    return db
+    .query(`DELETE FROM comments WHERE comment_id = $1;`,[comment_id])
+    .then((result)=>{
+        if(result.rowCount === 0){
+            return Promise.reject({status:404,msg:"Non-existent Comment ID"})
+        }
+        return result
+    })
+}


### PR DESCRIPTION
created new endpoint of: DELETE /api/comments/:comment_id

This patch endpoint should delete the given comment by comment_id

Happy Path:
DELETE204: delete the given comment by comment_id, respond with status 204 and no content.

Sad Path:
DELETE404: Respond with an error when passed ID is valid but non-existent
DELETE400: Respond with an error when an input comment ID is the incorrect type