### PR TITLE
11-get /api/articles (topic query)

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -340,7 +340,7 @@ describe("DELETE /api/comments/:comment_id", () => {
   });
 });
 
-describe("GET /api/users",()=>{
+describe("GET /api/users", () => {
   test("GET200: Endpoint responds with an array of users objects with username, name, avatar_url", () => {
     return request(app)
       .get("/api/users")
@@ -351,9 +351,49 @@ describe("GET /api/users",()=>{
           expect(user).toMatchObject({
             username: expect.any(String),
             name: expect.any(String),
-            avatar_url: expect.any(String)
+            avatar_url: expect.any(String),
           });
         });
       });
   });
-})
+});
+
+describe("GET /api/articles (topic query)", () => {
+  test("GET200: Endpoint accept topic query and responds articles with seleted topics", () => {
+    return request(app)
+      .get("/api/articles?topic=cats")
+      .expect(200)
+      .then(({ body: { allArticles } }) => {
+        expect(allArticles.length).toBe(1);
+        allArticles.forEach((article) => {
+          expect(article).toMatchObject({
+            title: expect.any(String),
+            topic: "cats",
+            author: expect.any(String),
+            body: expect.any(String),
+            created_at: expect.toBeDateString(),
+            article_img_url: expect.any(String),
+            comment_count: expect.any(Number),
+          });
+        });
+      });
+  });
+  test("GET404: Respond with an error when passed non-existent topic", () => {
+    return request(app)
+      .get("/api/articles?topic=abc")
+      .expect(404)
+      .then(({ body }) => {
+        const { msg } = body;
+        expect(msg).toBe("Non-existent Topic");
+      });
+  });
+  test("GET404: Respond with an error when invalid query", () => {
+    return request(app)
+      .get("/api/articles?abc=cats")
+      .expect(400)
+      .then(({ body }) => {
+        const { msg } = body;
+        expect(msg).toBe("Invalid query");
+      });
+  });
+});

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -387,7 +387,7 @@ describe("GET /api/articles (topic query)", () => {
         expect(msg).toBe("Non-existent Topic");
       });
   });
-  test("GET404: Respond with an error when invalid query", () => {
+  test.only("GET404: Respond with an error when invalid query", () => {
     return request(app)
       .get("/api/articles?abc=cats")
       .expect(400)

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -192,7 +192,7 @@ describe("POST /api/articles/:article_id/comments", () => {
       .expect(404)
       .then(({ body }) => {
         const { msg } = body;
-        expect(msg).toBe("Non-existent Article ID / Username");
+        expect(msg).toBe("Not Found");
       });
   });
   test("POST400: Respond with an error when an input article ID is the incorrect type", () => {
@@ -220,7 +220,7 @@ describe("POST /api/articles/:article_id/comments", () => {
       .expect(404)
       .then(({ body }) => {
         const { msg } = body;
-        expect(msg).toBe("Non-existent Article ID / Username");
+        expect(msg).toBe("Not Found");
       });
   });
   test("POST400: Respond with an error when incomplete/missing body", () => {
@@ -387,7 +387,7 @@ describe("GET /api/articles (topic query)", () => {
         expect(msg).toBe("Non-existent Topic");
       });
   });
-  test.only("GET404: Respond with an error when invalid query", () => {
+  test("GET404: Respond with an error when invalid query", () => {
     return request(app)
       .get("/api/articles?abc=cats")
       .expect(400)

--- a/app.js
+++ b/app.js
@@ -52,7 +52,7 @@ app.use((err, req, res, next) => {
   }
 
   if (err.code === "23503") {
-    res.status(404).send({ msg: "Non-existent Article ID / Username" });
+    res.status(404).send({ msg: "Not Found" });
   }
 
   if (err.code === "23502") {

--- a/app.js
+++ b/app.js
@@ -12,7 +12,7 @@ const {
   postComment,
   patchArticle,
   deleteComment,
-  getUsers
+  getUsers,
 } = require("./controllers");
 
 //Respond a list of all available endpoints from endpoint.json
@@ -29,9 +29,9 @@ app.get("/api/articles/:article_id/comments", getCommentsByArticleID);
 app.post("/api/articles/:article_id/comments", postComment);
 app.patch("/api/articles/:article_id", patchArticle);
 
-app.delete("/api/comments/:comment_id",deleteComment)
+app.delete("/api/comments/:comment_id", deleteComment);
 
-app.get("/api/users",getUsers)
+app.get("/api/users", getUsers);
 
 //Error Handling Middleware
 app.all("*", (req, res) => {

--- a/controllers.js
+++ b/controllers.js
@@ -8,7 +8,8 @@ const {
   createComment,
   updatedArticle,
   removeComment,
-  fetchUsers
+  fetchUsers,
+  validateQuery,
 } = require("./model");
 
 exports.getTopics = (req, res, next) => {
@@ -29,10 +30,16 @@ exports.getArticleById = (req, res, next) => {
 };
 
 exports.getArticles = (req, res, next) => {
-  const { sort_by, order } = req.query;
-  fetchArticles(sort_by, order).then((articles) => {
-    res.status(200).send({ allArticles: articles });
-  });
+  const { sort_by, order, topic } = req.query;
+  const queries = Object.keys(req.query);
+
+  Promise.all([fetchArticles(sort_by, order, topic), validateQuery(queries)])
+    .then(([articles]) => {
+      res.status(200).send({ allArticles: articles });
+    })
+    .catch((err) => {
+      next(err);
+    });
 };
 
 exports.getCommentsByArticleID = (req, res, next) => {
@@ -86,8 +93,8 @@ exports.deleteComment = (req, res, next) => {
     });
 };
 
-exports.getUsers = (req,res,next)=>{
-    fetchUsers().then((users)=>{
-        res.status(200).send({users})
-    })
-}
+exports.getUsers = (req, res, next) => {
+  fetchUsers().then((users) => {
+    res.status(200).send({ users });
+  });
+};

--- a/endpoints.json
+++ b/endpoints.json
@@ -113,5 +113,22 @@
         "avatar_url":"https://www.healthytherapies.com/wp-content/uploads/2016/06/Lime3.jpg"
       }]
     }
+  },
+  "GET /api/articles?topic=(query)":{
+    "description":"endpoint accept topic query, will respond with the articles by the topic value specified in the query",
+    "queries":["topic"],
+    "exampleQuery" : "GET /api/articles?topic=cats",
+    "exampleRespone":{
+      "articles":[{
+        "article_id": 5,
+        "title": "UNCOVERED: catspiracy to bring down democracy",
+        "topic": "cats",
+        "author": "rogersop",
+        "body":"Bastet walks amongst us, and the cats are taking arms!",
+        "votes":0,
+        "article_img_url":"https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700",
+        "comment_count" : 2
+      }]
+    }
   }
 }

--- a/model.js
+++ b/model.js
@@ -42,12 +42,18 @@ exports.fetchArticles = (sort_by = "created_at", order = "DESC", topic) => {
 };
 
 exports.validateQuery = (queries) => {
-  const validQuery = ["topic"];
-  const invalidQuery = queries.filter((query) => !validQuery.includes(query));
+  return db
+    .query(
+      `SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = N'articles'`
+    )
+    .then(({ rows }) => {
+      const validQuery = rows.flatMap(Object.values);
+      const invalidQuery = queries.filter((query) => !validQuery.includes(query));
 
-  if (invalidQuery.length > 0) {
-    return Promise.reject({ status: 400, msg: "Invalid query" });
-  }
+      if (invalidQuery.length > 0) {
+        return Promise.reject({ status: 400, msg: "Invalid query" });
+      }
+    });
 };
 
 exports.fetchCommentsByArticleID = (

--- a/model.js
+++ b/model.js
@@ -17,80 +17,108 @@ exports.fetchArticleById = (article_id) => {
     });
 };
 
-exports.fetchArticles = (sort_by = "created_at", order = "DESC") => {
+exports.fetchArticles = (sort_by = "created_at", order = "DESC", topic) => {
   let sqlQueryString = `SELECT articles.*,
     COUNT(comments.article_id)::INT AS comment_count
     FROM comments
     RIGHT JOIN articles
-    ON articles.article_id = comments.article_id
-    GROUP BY articles.article_id `;
+    ON articles.article_id = comments.article_id `;
 
-  sqlQueryString += `ORDER BY ${sort_by} ${order}`;
+  let topicValue = [];
 
-  return db.query(sqlQueryString).then(({ rows }) => {
+  if (topic) {
+    sqlQueryString += `WHERE topic LIKE $1 `;
+    topicValue.push(topic);
+  }
+
+  sqlQueryString += `GROUP BY articles.article_id ORDER BY ${sort_by} ${order}`;
+
+  return db.query(sqlQueryString, topicValue).then(({ rows }) => {
+    if (rows.length === 0) {
+      return Promise.reject({ status: 404, msg: "Non-existent Topic" });
+    }
     return rows;
   });
 };
 
-exports.fetchCommentsByArticleID = (article_id,sort_by = "created_at", order = "DESC") =>{
-    let sqlQueryString = `SELECT comments.* 
+exports.validateQuery = (queries) => {
+  const validQuery = ["topic"];
+  const invalidQuery = queries.filter((query) => !validQuery.includes(query));
+
+  if (invalidQuery.length > 0) {
+    return Promise.reject({ status: 400, msg: "Invalid query" });
+  }
+};
+
+exports.fetchCommentsByArticleID = (
+  article_id,
+  sort_by = "created_at",
+  order = "DESC"
+) => {
+  let sqlQueryString = `SELECT comments.* 
     FROM comments 
     INNER JOIN articles 
-    ON comments.article_id = articles.article_id `
+    ON comments.article_id = articles.article_id `;
 
-    sqlQueryString += `WHERE comments.article_id = $1 ORDER BY ${sort_by} ${order};`
+  sqlQueryString += `WHERE comments.article_id = $1 ORDER BY ${sort_by} ${order};`;
 
-    return db.query(sqlQueryString,[article_id])
-    .then(({rows})=>{
-        return rows
-    })
-}
+  return db.query(sqlQueryString, [article_id]).then(({ rows }) => {
+    return rows;
+  });
+};
 
 exports.checkArticleExists = (article_id) => {
-    return db.query(`SELECT * FROM articles WHERE article_id = $1`,[article_id])
-    .then(({rows})=>{
-        if (rows.length === 0) {
-            return Promise.reject({ status: 404, msg: "Non-existent Article ID" });
-          }
-        return rows
-    })
-}
+  return db
+    .query(`SELECT * FROM articles WHERE article_id = $1`, [article_id])
+    .then(({ rows }) => {
+      if (rows.length === 0) {
+        return Promise.reject({ status: 404, msg: "Non-existent Article ID" });
+      }
+      return rows;
+    });
+};
 
-exports.createComment = (article_id,newComment)=>{
-    return db
-    .query(`INSERT INTO comments(author,body,article_id) VALUES ($1,$2,$3) RETURNING *;`,[newComment.username,newComment.body,article_id])
-    .then(({rows})=>{
-        return rows[0]
-    })
-}
+exports.createComment = (article_id, newComment) => {
+  return db
+    .query(
+      `INSERT INTO comments(author,body,article_id) VALUES ($1,$2,$3) RETURNING *;`,
+      [newComment.username, newComment.body, article_id]
+    )
+    .then(({ rows }) => {
+      return rows[0];
+    });
+};
 
-exports.updatedArticle = (article_id, inc_votes) =>{
-    if(!inc_votes){
-        return Promise.reject({status:400,msg:"Invalid Form Body"})
-    }
-    return db
-    .query(`UPDATE articles SET votes = votes + $1 WHERE article_id = $2 RETURNING *;`,[inc_votes,article_id])
-    .then(({rows})=>{
-        if (rows.length === 0) {
-            return Promise.reject({ status: 404, msg: "Non-existent Article ID" });
-          }
-        return rows[0]
-    })
-}
+exports.updatedArticle = (article_id, inc_votes) => {
+  if (!inc_votes) {
+    return Promise.reject({ status: 400, msg: "Invalid Form Body" });
+  }
+  return db
+    .query(
+      `UPDATE articles SET votes = votes + $1 WHERE article_id = $2 RETURNING *;`,
+      [inc_votes, article_id]
+    )
+    .then(({ rows }) => {
+      if (rows.length === 0) {
+        return Promise.reject({ status: 404, msg: "Non-existent Article ID" });
+      }
+      return rows[0];
+    });
+};
 
-exports.removeComment = (comment_id) =>{
-    return db
-    .query(`DELETE FROM comments WHERE comment_id = $1;`,[comment_id])
-    .then((result)=>{
-        if(result.rowCount === 0){
-            return Promise.reject({status:404,msg:"Non-existent Comment ID"})
-        }
-        return result
-    })
-}
+exports.removeComment = (comment_id) => {
+  return db
+    .query(`DELETE FROM comments WHERE comment_id = $1;`, [comment_id])
+    .then((result) => {
+      if (result.rowCount === 0) {
+        return Promise.reject({ status: 404, msg: "Non-existent Comment ID" });
+      }
+      return result;
+    });
+};
 
-exports.fetchUsers = () =>{
-    return db.query(`SELECT * FROM users;`).then(({ rows }) => {
-        return rows;
-      });
-}
+exports.fetchUsers = () => {
+  return db.query(`SELECT * FROM users;`).then(({ rows }) => {
+    return rows;
+  });
+};

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
   },
   "jest": {
     "setupFilesAfterEnv": [
-      "jest-extended/all","jest-sorted"
+      "jest-extended/all",
+      "jest-sorted"
     ]
   }
 }


### PR DESCRIPTION

Added following feature for endpoint: **GET /api/articles**:

- accept query: topic, which filters the articles by the topic value specified in the query. If the query is not mentioned, the endpoint should respond with all articles.

Happy Path: 
_**/api/articles?topic="topic_name"**_
GET200: Endpoint accept topic query and responds articles with selected topics

Sad Path: 
GET404: Respond with an error when passed non-existent topic
GET404: Respond with an error when passed in invalid query