### PR TITLE
12-get-articles/article

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -358,7 +358,7 @@ describe("GET /api/users", () => {
   });
 });
 
-describe("GET /api/articles (topic query)", () => {
+describe("GET /api/articles (Add Feature: topic query)", () => {
   test("GET200: Endpoint accept topic query and responds articles with seleted topics", () => {
     return request(app)
       .get("/api/articles?topic=cats")
@@ -387,7 +387,7 @@ describe("GET /api/articles (topic query)", () => {
         expect(msg).toBe("Non-existent Topic");
       });
   });
-  test("GET404: Respond with an error when invalid query", () => {
+  test("GET400: Respond with an error when invalid query", () => {
     return request(app)
       .get("/api/articles?abc=cats")
       .expect(400)
@@ -397,3 +397,24 @@ describe("GET /api/articles (topic query)", () => {
       });
   });
 });
+
+describe("GET /api/articles/:article_id (Add Feature: comment_count)",()=>{
+  test("GET200: Endpoint responds with selected article by its ID and including it's total count of comment(comment_count)", () => {
+    return request(app)
+      .get("/api/articles/10")
+      .expect(200)
+      .then(({ body: { article } }) => {
+        expect(article).toMatchObject({
+          author: expect.any(String),
+          title: expect.any(String),
+          article_id: 10,
+          body: expect.any(String),
+          topic: expect.any(String),
+          created_at: expect.toBeDateString(),
+          votes: expect.any(Number),
+          article_img_url: expect.any(String),
+          comment_count: expect.any(Number)
+        });
+      });
+  });
+})

--- a/endpoints.json
+++ b/endpoints.json
@@ -10,7 +10,7 @@
     }
   },
   "GET /api/articles/:article_id": {
-    "description": "serves selected article by its id",
+    "description": "serves selected article by its id, and respond include total comment count of the selected article",
     "queries": [],
     "exampleResponse": {
       "articles": [
@@ -22,7 +22,8 @@
           "body": "Text from the article..",
           "created_at": "2020-07-09T20:11:00.000Z",
           "votes": 100,
-          "article_img_url": "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700"
+          "article_img_url": "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700",
+          "comment_count" : 2
         }
       ]
     }
@@ -119,22 +120,6 @@
     "queries":["topic"],
     "exampleQuery" : "GET /api/articles?topic=cats",
     "exampleRespone":{
-      "articles":[{
-        "article_id": 5,
-        "title": "UNCOVERED: catspiracy to bring down democracy",
-        "topic": "cats",
-        "author": "rogersop",
-        "body":"Bastet walks amongst us, and the cats are taking arms!",
-        "votes":0,
-        "article_img_url":"https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700",
-        "comment_count" : 2
-      }]
-    }
-  },
-  "GET /api/articles/:article_id (comment_count)":{
-    "description": "Added New Feature: An article response object should also now include comment_count",
-    "queries":["sort_by", "order"],
-    "exampleResponse":{
       "articles":[{
         "article_id": 5,
         "title": "UNCOVERED: catspiracy to bring down democracy",

--- a/endpoints.json
+++ b/endpoints.json
@@ -130,5 +130,21 @@
         "comment_count" : 2
       }]
     }
+  },
+  "GET /api/articles/:article_id (comment_count)":{
+    "description": "Added New Feature: An article response object should also now include comment_count",
+    "queries":["sort_by", "order"],
+    "exampleResponse":{
+      "articles":[{
+        "article_id": 5,
+        "title": "UNCOVERED: catspiracy to bring down democracy",
+        "topic": "cats",
+        "author": "rogersop",
+        "body":"Bastet walks amongst us, and the cats are taking arms!",
+        "votes":0,
+        "article_img_url":"https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700",
+        "comment_count" : 2
+      }]
+    }
   }
 }

--- a/model.js
+++ b/model.js
@@ -7,8 +7,16 @@ exports.fetchTopics = () => {
 };
 
 exports.fetchArticleById = (article_id) => {
+    let sqlQueryString = `SELECT articles.*,
+    COUNT(comments.article_id)::INT AS comment_count
+    FROM comments
+    RIGHT JOIN articles
+    ON articles.article_id = comments.article_id
+    WHERE articles.article_id = $1
+    GROUP BY articles.article_id`;
+
   return db
-    .query(`SELECT * FROM articles WHERE article_id = $1`, [article_id])
+    .query(sqlQueryString, [article_id])
     .then(({ rows }) => {
       if (rows.length === 0) {
         return Promise.reject({ status: 404, msg: "Non-existent ID" });


### PR DESCRIPTION
Added a new feature to endpoint **GET /api/articles/:article_id**

New feature: Respond now include the total comment count of the selected article

Happy Path:
GET200: serves selected article by its id, and comment count

Sad Path:
None (already did a GET400 for Non-existent ID and GET400 for bad request in previous test cases)