### PR TITLE
15- get /api/articles (sorting queries)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,17 +20,7 @@ https://github.com/booayl/backend-project
 npm install
 ```
 
-3. Seed Local Database
-```bash
-npm run setup-dbs
-```
-
-4. To Run tests
-```bash
-npm test
-```
-
-5. Create the .env files for development:
+3. Create the .env files for development:
 
 At the top level of your folder, create a new file name ```.env.development```
 
@@ -39,13 +29,23 @@ With the content:
 PGDATABASE=nc_news_dev
 ```
 
-6. Create the .env files for test:
+4. Create the .env files for test:
 
 Then, create another file name ```.env.test```
 
 With the content: 
 ```bash
 PGDATABASE=nc_news_test
+```
+
+5. Seed Local Database
+```bash
+npm run seed
+```
+
+6. To Run tests
+```bash
+npm test
 ```
 
 ## Minimum Required Versions 
@@ -55,7 +55,7 @@ Postgres  ```14.11```
 
 
 ## Usage
-For all available endpoints, run endpoint for information:
+For all available endpoints, run this endpoint for more information:
 ```bash
-https://news-app-u364.onrender.com/api
+GET https://news-app-u364.onrender.com/api
 ```

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -398,7 +398,7 @@ describe("GET /api/articles (Add Feature: topic query)", () => {
   });
 });
 
-describe("GET /api/articles/:article_id (Add Feature: comment_count)",()=>{
+describe("GET /api/articles/:article_id (Add Feature: comment_count)", () => {
   test("GET200: Endpoint responds with selected article by its ID and including it's total count of comment(comment_count)", () => {
     return request(app)
       .get("/api/articles/10")
@@ -413,8 +413,57 @@ describe("GET /api/articles/:article_id (Add Feature: comment_count)",()=>{
           created_at: expect.toBeDateString(),
           votes: expect.any(Number),
           article_img_url: expect.any(String),
-          comment_count: expect.any(Number)
+          comment_count: expect.any(Number),
         });
       });
   });
-})
+});
+
+describe("GET /api/articles (Add Feature: sorting queries)", () => {
+  test("GET200: Endpoint now accept queries for sort_by (any valid column from articles) and order (asc or desc)", () => {
+    return request(app)
+      .get("/api/articles?sort_by=comment_count&order=asc")
+      .expect(200)
+      .then(({ body: { allArticles } }) => {
+        expect(allArticles).toBeSortedBy("comment_count", { ascending: true });
+        allArticles.forEach((article) => {
+          expect(article).toMatchObject({
+            author: expect.any(String),
+            title: expect.any(String),
+            article_id: expect.any(Number),
+            topic: expect.any(String),
+            created_at: expect.toBeDateString(),
+            votes: expect.any(Number),
+            article_img_url: expect.any(String),
+            comment_count: expect.any(Number),
+          });
+        });
+      });
+  });
+  test("GET200: Sort_by and order queries are optional, if not exsist, default is sort_by = created_at, order = descending.", () => {
+    return request(app)
+      .get("/api/articles?sort_by=author")
+      .expect(200)
+      .then(({ body: { allArticles } }) => {
+        expect(allArticles).toBeSortedBy("author", { descending: true });
+      });
+  });
+  test("GET400: Respond with an error when passed in invalid / non-existent sort_by queries", () => {
+    return request(app)
+      .get("/api/articles?sort_by=abc")
+      .expect(400)
+      .then(({ body }) => {
+        const { msg } = body;
+        expect(msg).toBe("Invalid query");
+      });
+  });
+  test("GET400: Respond with an error when passed in invalid / non-existent order queries", () => {
+    return request(app)
+      .get("/api/articles?order=abc")
+      .expect(400)
+      .then(({ body }) => {
+        const { msg } = body;
+        expect(msg).toBe("Invalid query");
+      });
+  });
+});

--- a/endpoints.json
+++ b/endpoints.json
@@ -15,7 +15,7 @@
     "exampleResponse": {
       "articles": [
         {
-          "article_id":1,
+          "article_id": 1,
           "title": "Living in the shadow of a great man",
           "topic": "mitch",
           "author": "butter_bridge",
@@ -23,18 +23,31 @@
           "created_at": "2020-07-09T20:11:00.000Z",
           "votes": 100,
           "article_img_url": "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700",
-          "comment_count" : 2
+          "comment_count": 2
         }
       ]
     }
   },
   "GET /api/articles": {
-    "description": "serves an array of all articles",
-    "queries": ["author", "topic", "sort_by", "order"],
+    "description": [
+      "Serves an array of all articles, default sorted by date in descending order, accepting queries below:", 
+      {
+        "topic": "will respond with the articles by the topic value specified in the query.",
+        "sort_by": "will respond with the articles sort by any valid column from articles.",
+        "order": "will respond in selected (ascending/descending) order"
+      }
+    ],
+    "queries": ["topic", "sort_by", "order"],
+    "exampleQuery": [
+      "GET /api/articles?topic=cats",
+      "GET /api/articles?sort_by=comment_count&order=asc",
+      "GET /api/articles?sort_by=author",
+      "GET /api/article?order=asc"
+    ],
     "exampleResponse": {
       "articles": [
         {
-          "article_id":1,
+          "article_id": 1,
           "title": "Living in the shadow of a great man",
           "topic": "mitch",
           "author": "butter_bridge",
@@ -46,90 +59,116 @@
       ]
     }
   },
-   "GET /api/articles/:article_id/comments":{
-    "description":"responds with an array of comments objects from selected article by article ID. Comments served with the most recent comments first.",
-    "queries":["sort_by", "order"],
-    "exampleResponse":{
-      "comments":[
+  "GET /api/articles/:article_id/comments": {
+    "description": "responds with an array of comments objects from selected article by article ID. Comments served with the most recent comments first.",
+    "queries": ["sort_by", "order"],
+    "exampleResponse": {
+      "comments": [
         {
-          "comment_id":1,
-          "votes":16,
-          "created_at":"2020-07-09T20:11:00.000Z",
-          "author":"butter_bridge",
-          "body":" Oh, I've got compassion running out of my nose, pal! I'm the Sultan of Sentiment!",
-          "article_id":"1"
+          "comment_id": 1,
+          "votes": 16,
+          "created_at": "2020-07-09T20:11:00.000Z",
+          "author": "butter_bridge",
+          "body": " Oh, I've got compassion running out of my nose, pal! I'm the Sultan of Sentiment!",
+          "article_id": "1"
         }
       ]
     }
   },
-  "POST /api/articles/:article_id/comments":{
-    "description":"add a comment for an article (seleted by article ID), accept properties: username and body. Will responds with the posted comment.",
+  "POST /api/articles/:article_id/comments": {
+    "description": "add a comment for an article (seleted by article ID), accept properties: username and body. Will responds with the posted comment.",
     "queries": [],
-    " exampleRequest":{
-      "username" : "rogersop",
-      "body":"Isn't that sweet, i guess so"
+    " exampleRequest": {
+      "username": "rogersop",
+      "body": "Isn't that sweet, i guess so"
     },
-    "exampleResponse":{
-      "postedComment":[
-        {"comment_id":19,
-        "votes":22,
-        "created_at":"2020-07-09T20:11:00.000Z",
-        "author":"rogersop",
-        "body":"Isn't that sweet, i guess so",
-        "article_id":"2"
-      }
+    "exampleResponse": {
+      "postedComment": [
+        {
+          "comment_id": 19,
+          "votes": 22,
+          "created_at": "2020-07-09T20:11:00.000Z",
+          "author": "rogersop",
+          "body": "Isn't that sweet, i guess so",
+          "article_id": "2"
+        }
       ]
     }
   },
-  "PATCH /api/articles/:article_id":{
-    "description":"update an article by article_id, accept properties: newVotes (in the form of key pair values, ex: { inc_votes : 1 }, which increase the selected article's vote by 1), and responds with the updated article.",
-    "queries":[],
-    "exampleRequest":{
-      "inc_votes" : 1 
+  "PATCH /api/articles/:article_id": {
+    "description": "update an article by article_id, accept properties: newVotes (in the form of key pair values, ex: { inc_votes : 1 }, which increase the selected article's vote by 1), and responds with the updated article.",
+    "queries": [],
+    "exampleRequest": {
+      "inc_votes": 1
     },
-    "exampleResponse":{
-      "updatedArticle":[{
-        "article_id":1,
-        "title": "Living in the shadow of a great man",
-        "topic": "mitch",
-        "author": "butter_bridge",
-        "created_at": "2020-07-09T20:11:00.000Z",
-        "votes": 101,
-        "article_img_url": "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700"
-      }]
+    "exampleResponse": {
+      "updatedArticle": [
+        {
+          "article_id": 1,
+          "title": "Living in the shadow of a great man",
+          "topic": "mitch",
+          "author": "butter_bridge",
+          "created_at": "2020-07-09T20:11:00.000Z",
+          "votes": 101,
+          "article_img_url": "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700"
+        }
+      ]
     }
   },
-  "DELETE /api/comments/:comment_id":{
-    "description":"delete the given comment by comment_id",
-    "queries":[],
-    "exampleResponse":"status 204 and no content"
+  "DELETE /api/comments/:comment_id": {
+    "description": "delete the given comment by comment_id",
+    "queries": [],
+    "exampleResponse": "status 204 and no content"
   },
-  "GET /api/users":{
-    "description":"responds with all users, which are an array of objects with: username, name, avatar_url",
-    "queries":[],
-    "exampleResponse":{
-      "users":[{
-        "username": "butter_bridge",
-        "name":"jonny",
-        "avatar_url":"https://www.healthytherapies.com/wp-content/uploads/2016/06/Lime3.jpg"
-      }]
+  "GET /api/users": {
+    "description": "responds with all users, which are an array of objects with: username, name, avatar_url",
+    "queries": [],
+    "exampleResponse": {
+      "users": [
+        {
+          "username": "butter_bridge",
+          "name": "jonny",
+          "avatar_url": "https://www.healthytherapies.com/wp-content/uploads/2016/06/Lime3.jpg"
+        }
+      ]
     }
   },
-  "GET /api/articles?topic=(query)":{
-    "description":"endpoint accept topic query, will respond with the articles by the topic value specified in the query",
-    "queries":["topic"],
-    "exampleQuery" : "GET /api/articles?topic=cats",
-    "exampleRespone":{
-      "articles":[{
-        "article_id": 5,
-        "title": "UNCOVERED: catspiracy to bring down democracy",
-        "topic": "cats",
-        "author": "rogersop",
-        "body":"Bastet walks amongst us, and the cats are taking arms!",
-        "votes":0,
-        "article_img_url":"https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700",
-        "comment_count" : 2
-      }]
+  "GET /api/articles?topic=(query)": {
+    "description": "endpoint accept topic query, will respond with the articles by the topic value specified in the query",
+    "queries": ["topic"],
+    "exampleQuery": "GET /api/articles?topic=cats",
+    "exampleRespone": {
+      "articles": [
+        {
+          "article_id": 5,
+          "title": "UNCOVERED: catspiracy to bring down democracy",
+          "topic": "cats",
+          "author": "rogersop",
+          "body": "Bastet walks amongst us, and the cats are taking arms!",
+          "votes": 0,
+          "article_img_url": "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700",
+          "comment_count": 2
+        }
+      ]
+    }
+  },
+  "GET /api/articles?sort_by=(any existing column)&order=(asc/desc)": {
+    "description": "endpoint accept sort_by and order query, will respond with articles in ",
+    "queries": ["topic"],
+    "exampleQuery": "GET /api/articles?topic=cats",
+    "exampleRespone": {
+      "articles": [
+        {
+          "article_id": 5,
+          "title": "UNCOVERED: catspiracy to bring down democracy",
+          "topic": "cats",
+          "author": "rogersop",
+          "body": "Bastet walks amongst us, and the cats are taking arms!",
+          "votes": 0,
+          "article_img_url": "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700",
+          "comment_count": 2
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
Added a new feature to endpoint **GET /api/articles**

**New feature:**
Endpoint now accept the following queries:
- sort_by, which sorts the articles by any valid column (defaults to the created_at date).
- order, which can be set to asc or desc for ascending or descending (defaults to descending).

Happy Path:
GET200: Respond with requested queries (sort_by and order)
GET200: Queries are optional, if non existent, default is sort_by = created_at, order = descending

Sad Path:
GET400: Respond with an error when passed in invalid / non-existent sort_by queries
GET400: Respond with an error when passed in invalid / non-existent order queries