### PR TITLE
19-post /api/articles

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -563,3 +563,111 @@ describe("PATCH /api/comments/:comment_id", () => {
       });
   });
 });
+
+describe("POST /api/articles", () => {
+  test("POST201: adds a new article, will responds with the newly added article.", () => {
+    const newPost = {
+      author: "rogersop",
+      title: "Which is your favourite Taylor Swift boyfriend",
+      body: "Joe, I mean have you seen the easter eggs for The Tortured Poets Department? ",
+      topic : "cats",
+      article_img_url : "https://media.tenor.com/K-4KulpZoNUAAAAM/yes-taylor-swift.gif"
+    };
+    return request(app)
+      .post("/api/articles")
+      .send(newPost)
+      .expect(201)
+      .then(({ body: { newArticle } }) => {
+        expect(newArticle).toMatchObject({
+          article_id: expect.any(Number),
+          votes: expect.any(Number),
+          created_at: expect.toBeDateString(),
+          author: newPost.author,
+          body: newPost.body,
+          title: newPost.title,
+          topic: newPost.topic,
+          article_img_url: newPost.article_img_url,
+        });
+      });  
+  });
+  test("POST201: Responds with the newly added article includes comment_count", () => {
+    const newPost = {
+      author: "rogersop",
+      title: "Which is your favourite Taylor Swift boyfriend",
+      body: "Joe, I mean have you seen the easter eggs for The Tortured Poets Department? ",
+      topic : "cats",
+      article_img_url : "https://media.tenor.com/K-4KulpZoNUAAAAM/yes-taylor-swift.gif"
+    };
+    return request(app)
+      .post("/api/articles")
+      .send(newPost)
+      .expect(201)
+      .then(({ body: { newArticle } }) => {
+        expect(newArticle).toMatchObject({
+          article_id: expect.any(Number),
+          votes: expect.any(Number),
+          created_at: expect.toBeDateString(),
+          author: newPost.author,
+          body: newPost.body,
+          title: newPost.title,
+          topic: newPost.topic,
+          article_img_url: newPost.article_img_url,
+          comment_count: expect.any(Number)
+        });
+      });  
+  });
+  test("POST201: will default article_img_url if not provided", () => {
+    const newPost = {
+      author: "rogersop",
+      title: "Which is your favourite Taylor Swift boyfriend",
+      body: "Joe, I mean have you seen the easter eggs for The Tortured Poets Department? ",
+      topic : "cats",
+    };
+    return request(app)
+      .post("/api/articles")
+      .send(newPost)
+      .expect(201)
+      .then(({ body: { newArticle } }) => {
+        expect(newArticle).toMatchObject({
+          article_id: expect.any(Number),
+          votes: expect.any(Number),
+          created_at: expect.toBeDateString(),
+          author: newPost.author,
+          body: newPost.body,
+          title: newPost.title,
+          topic: newPost.topic,
+          article_img_url: "https://grin2b.com/wp-content/uploads/2017/01/Grin2B_icon_NEWS.png",
+          comment_count: expect.any(Number)
+        });
+      });  
+  });
+  test("POST404: Respond with an error when new foreign key (author & topic) is invalid or non-existence", () => {
+    const newPost = {
+      author: 123,
+      title: "Which is your favourite Taylor Swift boyfriend",
+      body: "Joe, I mean have you seen the easter eggs for The Tortured Poets Department? ",
+      topic : "abc",
+    };
+    return request(app)
+      .post("/api/articles")
+      .send(newPost)
+      .expect(404)
+      .then(({ body }) => {
+        const { msg } = body;
+        expect(msg).toBe("Not Found");
+      });
+  });
+  test("POST400: Respond with an error when incomplete/missing body", () => {
+    const newComment = {
+      author: "rogersop",
+    };
+    return request(app)
+      .post("/api/articles/2/comments")
+      .send(newComment)
+      .expect(400)
+      .then(({ body }) => {
+        const { msg } = body;
+        expect(msg).toBe("Incomplete/Missing Body");
+      });
+  });
+});

--- a/controllers.js
+++ b/controllers.js
@@ -12,6 +12,7 @@ const {
   validateQuery,
   retrieveUser,
   updateComment,
+  createArticle
 } = require("./model");
 
 exports.getTopics = (req, res, next) => {
@@ -123,3 +124,14 @@ exports.patchComment = (req, res, next) => {
       next(err);
     });
 };
+
+exports.postArticle = (req,res,next) =>{
+  const newArticle = req.body;
+  createArticle(newArticle)
+    .then((article) => {
+      res.status(201).send({ newArticle: article });
+    })
+    .catch((err) => {
+      next(err);
+    });
+}

--- a/endpoints.json
+++ b/endpoints.json
@@ -160,5 +160,31 @@
         }
       ]
     }
+  },
+  "POST /api/articles":{
+    "description": "adds a new article, will responds with the newly added article. Article_img_url will default if not provided.",
+    "queries": [],
+    " exampleRequest": {
+      "author": "rogersop",
+      "title": "Which is your favourite Taylor Swift boyfriend",
+      "body": "Joe, I mean have you seen the easter eggs for The Tortured Poets Department? ",
+      "topic" : "cats",
+      "article_img_url" : "https://media.tenor.com/K-4KulpZoNUAAAAM/yes-taylor-swift.gif"
+    },
+    "exampleResponse": {
+      "postedArticle": [
+        {
+          "article_id": "2",
+          "author": "rogersop",
+          "title": "Which is your favourite Taylor Swift boyfriend",
+          "body": "Joe, I mean have you seen the easter eggs for The Tortured Poets Department? ",
+          "topic" : "cats",
+          "article_img_url" : "https://media.tenor.com/K-4KulpZoNUAAAAM/yes-taylor-swift.gif",
+          "votes": 22,
+          "created_at": "2020-07-09T20:11:00.000Z",
+          "comment_count" : 2
+        }
+      ]
+    }
   }
 }

--- a/routes/articles-router.js
+++ b/routes/articles-router.js
@@ -5,10 +5,13 @@ const {
     getArticles,
     getCommentsByArticleID,
     postComment,
-    patchArticle
+    patchArticle,
+    postArticle
   } = require("../controllers");
   
-articleRouter.get('/', getArticles);
+articleRouter.route('/')
+.get(getArticles)
+.post(postArticle);
 
 articleRouter.route('/:article_id')
 .get(getArticleById)


### PR DESCRIPTION
Added new endpoint of: POST /api/articles

This new endpoint allows client to adds new article, and will responds with the newly added article.
Accept Request Body:
- author
- title
- body
- topic
- article_img_url  _(will default if not provided)_

Will respond newly added article in:
- article_id
- author
- title
- body
- topic
- article_img_url
- votes
- created_at
- comment_count

Happy Path:
POST201: adds a new article, will responds with the newly added article.

Sad Path:
POST404: Respond with an error when foreign key (author & topic) is invalid or non-existence
POST400: Respond with an error when incomplete/missing body
